### PR TITLE
No need to download SimpleDirectoryReader because it is already imported

### DIFF
--- a/sample-application/chatbot.py
+++ b/sample-application/chatbot.py
@@ -22,7 +22,6 @@ from azure.identity import ManagedIdentityCredential
 
 import streamlit as st
 from llama_index import (
-    download_loader,
     SimpleDirectoryReader,
     LLMPredictor,
     GPTVectorStoreIndex,
@@ -152,7 +151,6 @@ elif os.path.exists(index_file):
         storage_context, index_id="vector_index", service_context=service_context
     )
 
-    SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
     loader = SimpleDirectoryReader(doc_path, recursive=True, exclude_hidden=True)
     documents = loader.load_data()
     doc_filename = os.listdir(doc_path)[0]


### PR DESCRIPTION
I am having issues with the function `download_loader`.  It is actually not needed because `SimpleDirectoryReader` is already imported.

This PR fixes the following issue, that I assume it was because if a failed download:

![Screenshot 2023-06-05 at 13 34 34](https://github.com/Azure-Samples/azure-openai-terraform-deployment-sample/assets/789701/36f3b008-9e2b-4031-879d-2e0d7c522073)
