### PR TITLE
text-embedding-ada-002 version 2

### DIFF
--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -27,7 +27,7 @@ module "openai" {
       name          = "text-embedding-ada-002"
       model_format  = "OpenAI"
       model_name    = "text-embedding-ada-002"
-      model_version = "1"
+      model_version = "2"
       scale_type    = "Standard"
     },
   }


### PR DESCRIPTION
Updating version for model text-embedding-ada-002

without this change I was getting the error:

```
│ Deployment Name: "text-embedding-ada-002"): performing CreateOrUpdate: unexpected status 400 with error: InvalidResourceProperties: The specified scale type 'Standard'
│ of account deployment is not supported by the model 'text-embedding-ada-002'.
```

