### PR TITLE
Do not use kwargs when not necessary

### DIFF
--- a/sample-application/chatbot.py
+++ b/sample-application/chatbot.py
@@ -78,12 +78,10 @@ uploaded_file = st.file_uploader("Choose a file")
 # Create the chat llm
 llm = AzureChatOpenAI(
     deployment_name="gpt-35-turbo",
-    model_kwargs={
-        "api_key": st.session_state.config["OPENAI_API_KEY"],
-        "api_base": st.session_state.config["OPENAI_API_BASE"],
-        "api_type": st.session_state.config["OPENAI_API_TYPE"],
-        "api_version": st.session_state.config["OPENAI_API_VERSION"],
-    },
+    openai_api_key=st.session_state.config["OPENAI_API_KEY"],
+    openai_api_base=st.session_state.config["OPENAI_API_BASE"],
+    openai_api_type=st.session_state.config["OPENAI_API_TYPE"],
+    openai_api_version=st.session_state.config["OPENAI_API_VERSION"],
 )
 
 # Create the embedding llm


### PR DESCRIPTION
Passing kwargs does not satisfy pydantic
This was working before because we had dummy env vars in the container making pydantic happy
<img width="745" alt="Screenshot 2023-06-06 at 11 10 38" src="https://github.com/Azure-Samples/azure-openai-terraform-deployment-sample/assets/789701/237fbb33-2c67-4f84-aedb-0792f409fc59">
