### PR TITLE
Improve devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "name": "Terraform AzureCLI and Kubectl",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "postAttachCommand": "bash .devcontainer/script.sh",
   "customizations": {
     "vscode": {
@@ -13,9 +14,9 @@
   "features": {
     "azure-cli": "latest",
     "terraform": {
-      "version": "latest",
-      "tflint": "latest",
-      "terragrunt": "latest"
+      "version": "1.4.6",
+      "tflint": "0.46.1",
+      "terragrunt": "0.47.0"
     },
     "kubectl-helm-minikube": {
       "version": "latest",


### PR DESCRIPTION
* Specify a base image that supports also arm64 for Apple Silicon.
* Fix Terraform component versions. This fixes a bug with the latest version of tflint that prevents the feature from working correctly:
  * https://github.com/devcontainers/features/issues/581

