### PR TITLE
Increase capacity value to a resonable number

### DIFF
--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -22,6 +22,7 @@ module "openai" {
       model_name    = "gpt-35-turbo"
       model_version = "0301"
       scale_type    = "Standard"
+      capacity      = 120
     },
     "embedding_model" = {
       name          = "text-embedding-ada-002"
@@ -29,6 +30,7 @@ module "openai" {
       model_name    = "text-embedding-ada-002"
       model_version = "2"
       scale_type    = "Standard"
+      capacity      = 120
     },
   }
   depends_on = [


### PR DESCRIPTION
The upstream module defaulted the capacity to 1000 TPM that is too low to do anything.

Defaulting to 120.000 TPM so that with 2 models we use 100% of the capacity
